### PR TITLE
Feature/change-person-object-to-be-flat

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 ## Versioning
 | Version | Description | Date |
 | - | - | - |
+| 2.1.0   | Updated to output person object flat (where necessary) | 2023/04/20  |
 | 2.0.0   | Updated to use new endpoints and support extensions | 2022/12/14  |
 | 1.1.1   | Updated to handle too many request errors | 2022/09/19  |
 | 1.1.0   | Updated perforance and logging | 2022/05/24  |

--- a/mapping.assignments.includePersonsWithoutAssignments.json
+++ b/mapping.assignments.includePersonsWithoutAssignments.json
@@ -2,40 +2,40 @@
     "personMappings": [
         {
             "name": "Contact.Business.Email",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof source.BusinessEmailAddress !== 'undefined' && source.BusinessEmailAddress) {\r\n        returnValue = source.BusinessEmailAddress.address;\r\n    };\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "BusinessEmailAddress_address",
             "validation": {
                 "required": false
             }
         },
         {
             "name": "Contact.Business.Phone.Fixed",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof source.BusinessPhoneNumber !== 'undefined' && source.BusinessPhoneNumber) {\r\n        returnValue = source.BusinessPhoneNumber.number;\r\n    };\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "BusinessPhoneNumber_number",
             "validation": {
                 "required": false
             }
         },
         {
             "name": "Contact.Business.Phone.Mobile",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof source.MobilePhoneNumber !== 'undefined' && source.MobilePhoneNumber) {\r\n        returnValue = source.MobilePhoneNumber.number;\r\n    };\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "MobilePhoneNumber_number",
             "validation": {
                 "required": false
             }
         },
         {
             "name": "Contact.Personal.Email",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof source.PrivateEmailAddress !== 'undefined' && source.PrivateEmailAddress) {\r\n        returnValue = source.PrivateEmailAddress.address;\r\n    };\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "PrivateEmailAddress_address",
             "validation": {
                 "required": false
             }
         },
         {
             "name": "Details.Gender",
-            "mode": "field",
-            "value": "gender",
+            "mode": "complex",
+            "value": "function getValue() {\r\n    let returnValue = '';\r\n\r\n    switch (source.gender) {\r\n        case \"Female\": {\r\n            returnValue = \"V\";\r\n            break;\r\n        }\r\n        case \"Male\": {\r\n            returnValue = \"M\";\r\n            break;\r\n        }\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -51,7 +51,7 @@
         {
             "name": "Name.Convention",
             "mode": "complex",
-            "value": "function getValue() {\r\n    let returnValue = '';\r\n\r\n    switch (source.nameAssembleOrder) {\r\n        case \"P\": {\r\n            returnValue = \"P\";\r\n            break;\r\n        }\r\n        case \"E\": {\r\n            returnValue = \"B\";\r\n            break;\r\n        }\r\n        case \"B\": {\r\n            returnValue = \"PB\";\r\n            break;\r\n        }\r\n        case \"C\": {\r\n            returnValue = \"BP\";\r\n            break;\r\n        }\r\n        case \"D\": {\r\n            returnValue = \"BP\";\r\n            break;\r\n        }\r\n        default: {\r\n            returnValue = \"B\";\r\n            break;\r\n        }\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n \r\ngetValue();",
+            "value": "function getValue() {\r\n    let returnValue = '';\r\n\r\n    switch (source.nameAssembleOrder) {\r\n        case \"P\": {\r\n            returnValue = \"P\";\r\n            break;\r\n        }\r\n        case \"E\": {\r\n            returnValue = \"B\";\r\n            break;\r\n        }\r\n        case \"B\": {\r\n            returnValue = \"PB\";\r\n            break;\r\n        }\r\n        case \"C\": {\r\n            returnValue = \"BP\";\r\n            break;\r\n        }\r\n        case \"D\": {\r\n            returnValue = \"BP\";\r\n            break;\r\n        }\r\n        default: {\r\n            returnValue = \"B\";\r\n            break;\r\n        }\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -117,7 +117,7 @@
         {
             "name": "CostCenter.Code",
             "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = '';\r\n\r\n    if (typeof sourceContract.assignment_costAllocation !== 'undefined' && sourceContract.assignment_costAllocation) {\r\n        returnValue = sourceContract.assignment_costAllocation.costCenterCode;\r\n    } else if (typeof sourceContract.employment_costAllocation !== 'undefined' && sourceContract.employment_costAllocation) {\r\n        returnValue = sourceContract.employment_costAllocation.costCenterCode;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    assignmentValue = sourceContract.assignment_costAllocation_costCenterCode;\r\n    employmentValue = sourceContract.employment_costAllocation_costCenterCode;\r\n    // if assignment value not availble, fall back to employment value\r\n    if (typeof assignmentValue !== 'undefined' && assignmentValue) {\r\n        returnValue = assignmentValue;\r\n    } else if (typeof employmentValue !== 'undefined' && employmentValue) {\r\n        returnValue = employmentValue;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -125,7 +125,7 @@
         {
             "name": "CostCenter.ExternalId",
             "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof sourceContract.assignment_costAllocation !== 'undefined' && sourceContract.assignment_costAllocation) {\r\n        returnValue = sourceContract.assignment_costAllocation.costCenterCode;\r\n    } else if (typeof sourceContract.employment_costAllocation !== 'undefined' && sourceContract.employment_costAllocation) {\r\n        returnValue = sourceContract.employment_costAllocation.costCenterCode;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    assignmentValue = sourceContract.assignment_costAllocation_costCenterCode;\r\n    employmentValue = sourceContract.employment_costAllocation_costCenterCode;\r\n    // if assignment value not availble, fall back to employment value\r\n    if (typeof assignmentValue !== 'undefined' && assignmentValue) {\r\n        returnValue = assignmentValue;\r\n    } else if (typeof employmentValue !== 'undefined' && employmentValue) {\r\n        returnValue = employmentValue;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -133,7 +133,7 @@
         {
             "name": "CostCenter.Name",
             "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof sourceContract.assignment_costAllocation !== 'undefined' && sourceContract.assignment_costAllocation) {\r\n        returnValue = sourceContract.assignment_costAllocation.costCenterName;\r\n    } else if (typeof sourceContract.employment_costAllocation !== 'undefined' && sourceContract.employment_costAllocation) {\r\n        returnValue = sourceContract.employment_costAllocation.costCenterName;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    assignmentValue = sourceContract.assignment_costAllocation_costCenterName;\r\n    employmentValue = sourceContract.employment_costAllocation_costCenterName;\r\n    // if assignment value not availble, fall back to employment value\r\n    if (typeof assignmentValue !== 'undefined' && assignmentValue) {\r\n        returnValue = assignmentValue;\r\n    } else if (typeof employmentValue !== 'undefined' && employmentValue) {\r\n        returnValue = employmentValue;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -141,7 +141,7 @@
         {
             "name": "Department.DisplayName",
             "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof sourceContract.assignment_organizationUnitName !== 'undefined' && sourceContract.assignment_organizationUnitName) {\r\n        returnValue = sourceContract.assignment_organizationUnitName;\r\n    } else if (typeof sourceContract.employment_organizationUnitName !== 'undefined' && sourceContract.employment_organizationUnitName) {\r\n        returnValue = sourceContract.employment_organizationUnitName;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    assignmentValue = sourceContract.assignment_organizationUnit_fullName;\r\n    employmentValue = sourceContract.employment_organizationUnit_fullName;\r\n    // if assignment value not availble, fall back to employment value\r\n    if (typeof assignmentValue !== 'undefined' && assignmentValue) {\r\n        returnValue = assignmentValue;\r\n    } else if (typeof employmentValue !== 'undefined' && employmentValue) {\r\n        returnValue = employmentValue;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -149,7 +149,7 @@
         {
             "name": "Department.ExternalId",
             "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof sourceContract.assignment_organizationUnitCode !== 'undefined' && sourceContract.assignment_organizationUnitCode) {\r\n        returnValue = sourceContract.assignment_organizationUnitCode;\r\n    } else if (typeof sourceContract.employment_organizationUnitCode !== 'undefined' && sourceContract.employment_organizationUnitCode) {\r\n        returnValue = sourceContract.employment_organizationUnitCode;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    assignmentValue = sourceContract.assignment_organizationUnit_id;\r\n    employmentValue = sourceContract.employment_organizationUnit_id;\r\n    // if assignment value not availble, fall back to employment value\r\n    if (typeof assignmentValue !== 'undefined' && assignmentValue) {\r\n        returnValue = assignmentValue;\r\n    } else if (typeof employmentValue !== 'undefined' && employmentValue) {\r\n        returnValue = employmentValue;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -157,7 +157,7 @@
         {
             "name": "Details.HoursPerWeek",
             "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof sourceContract.assignment_workingAmount !== 'undefined' && sourceContract.assignment_workingAmount) {\r\n        returnValue = sourceContract.assignment_workingAmount.amountOfWork;\r\n    } else if (typeof sourceContract.employment_workingAmount !== 'undefined' && sourceContract.employment_workingAmount) {\r\n        returnValue = sourceContract.employment_workingAmount.amountOfWork;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    assignmentValue = sourceContract.assignment_workingAmount.amountOfWork;\r\n    employmentValue = sourceContract.employment_workingAmount.amountOfWork;\r\n    // if assignment value not availble, fall back to employment value\r\n    if (typeof assignmentValue !== 'undefined' && assignmentValue) {\r\n        returnValue = assignmentValue;\r\n    } else if (typeof employmentValue !== 'undefined' && employmentValue) {\r\n        returnValue = employmentValue;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -165,7 +165,7 @@
         {
             "name": "EndDate",
             "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof sourceContract.assignment_endDate !== 'undefined' && sourceContract.assignment_endDate) {\r\n        if(sourceContract.assignment_endDate == '9999-12-31'){\r\n            returnValue = null;\r\n        } else {\r\n            returnValue = sourceContract.assignment_endDate;\r\n        }\r\n    } else if (typeof sourceContract.employment_dischargeDate !== 'undefined' && sourceContract.employment_dischargeDate) {\r\n        if(sourceContract.employment_dischargeDate == '9999-12-31'){\r\n            returnValue = null;\r\n        } else {\r\n            returnValue = sourceContract.employment_dischargeDate;\r\n        }\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    assignmentValue = sourceContract.assignment_endDate;\r\n    employmentValue = sourceContract.employment_dischargeDate;\r\n    // if assignment value not availble, fall back to employment value\r\n    if (typeof assignmentValue !== 'undefined' && assignmentValue) {\r\n        endDate = assignmentValue;\r\n    } else if (typeof employmentValue !== 'undefined' && employmentValue) {\r\n        endDate = employmentValue;\r\n    }\r\n\r\n    if(endDate == '9999-12-31'){\r\n        returnValue = null;\r\n    } else {\r\n        returnValue = endDate;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -173,7 +173,7 @@
         {
             "name": "ExternalId",
             "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof sourceContract.assignment_id !== 'undefined' && sourceContract.assignment_id) {\r\n        returnValue = sourceContract.assignment_id;\r\n    } else if (typeof sourceContract.employment_contractId !== 'undefined' && sourceContract.employment_contractId) {\r\n        returnValue = sourceContract.employment_contractId;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    assignmentValue = sourceContract.assignment_id;\r\n    employmentValue = sourceContract.employment_id;\r\n    // if assignment value not availble, fall back to employment value\r\n    if (typeof assignmentValue !== 'undefined' && assignmentValue) {\r\n        returnValue = assignmentValue;\r\n    } else if (typeof employmentValue !== 'undefined' && employmentValue) {\r\n        returnValue = employmentValue;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -197,7 +197,15 @@
         {
             "name": "StartDate",
             "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof sourceContract.assignment_startDate !== 'undefined' && sourceContract.assignment_startDate) {\r\n        returnValue = sourceContract.assignment_startDate;\r\n    } else if (typeof sourceContract.employment_hireDate !== 'undefined' && sourceContract.employment_hireDate) {\r\n        returnValue = sourceContract.employment_hireDate;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    assignmentValue = sourceContract.assignment_startDate;\r\n    employmentValue = sourceContract.employment_hireDate;\r\n    // if assignment value not availble, fall back to employment value\r\n    if (typeof assignmentValue !== 'undefined' && assignmentValue) {\r\n        returnValue = assignmentValue;\r\n    } else if (typeof employmentValue !== 'undefined' && employmentValue) {\r\n        returnValue = employmentValue;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "validation": {
+                "required": false
+            }
+        },
+        {
+            "name": "Title.Code",
+            "mode": "complex",
+            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    assignmentValue = sourceContract.assignment_jobProfile_shortName;\r\n    employmentValue = sourceContract.employment_jobProfile_shortName;\r\n    // if assignment value not availble, fall back to employment value\r\n    if (typeof assignmentValue !== 'undefined' && assignmentValue) {\r\n        returnValue = assignmentValue;\r\n    } else if (typeof employmentValue !== 'undefined' && employmentValue) {\r\n        returnValue = employmentValue;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -205,7 +213,7 @@
         {
             "name": "Title.ExternalId",
             "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof sourceContract.assignment_jobProfile !== 'undefined' && sourceContract.assignment_jobProfile) {\r\n        returnValue = sourceContract.assignment_jobProfile.shortName;\r\n    } else if (typeof sourceContract.employment_jobProfile !== 'undefined' && sourceContract.employment_jobProfile) {\r\n        returnValue = sourceContract.employment_jobProfile.shortName;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    assignmentValue = sourceContract.assignment_jobProfile_id;\r\n    employmentValue = sourceContract.employment_jobProfile_id;\r\n    // if assignment value not availble, fall back to employment value\r\n    if (typeof assignmentValue !== 'undefined' && assignmentValue) {\r\n        returnValue = assignmentValue;\r\n    } else if (typeof employmentValue !== 'undefined' && employmentValue) {\r\n        returnValue = employmentValue;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -213,7 +221,7 @@
         {
             "name": "Title.Name",
             "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof sourceContract.assignment_jobProfile !== 'undefined' && sourceContract.assignment_jobProfile) {\r\n        returnValue = sourceContract.assignment_jobProfile.fullName;\r\n    } else if (typeof sourceContract.employment_jobProfile !== 'undefined' && sourceContract.employment_jobProfile) {\r\n        returnValue = sourceContract.employment_jobProfile.fullName;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    assignmentValue = sourceContract.assignment_jobProfile_fullName;\r\n    employmentValue = sourceContract.employment_jobProfile_fullName;\r\n    // if assignment value not availble, fall back to employment value\r\n    if (typeof assignmentValue !== 'undefined' && assignmentValue) {\r\n        returnValue = assignmentValue;\r\n    } else if (typeof employmentValue !== 'undefined' && employmentValue) {\r\n        returnValue = employmentValue;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }

--- a/mapping.assignments.json
+++ b/mapping.assignments.json
@@ -2,40 +2,40 @@
     "personMappings": [
         {
             "name": "Contact.Business.Email",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof source.BusinessEmailAddress !== 'undefined' && source.BusinessEmailAddress) {\r\n        returnValue = source.BusinessEmailAddress.address;\r\n    };\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "BusinessEmailAddress_address",
             "validation": {
                 "required": false
             }
         },
         {
             "name": "Contact.Business.Phone.Fixed",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof source.BusinessPhoneNumber !== 'undefined' && source.BusinessPhoneNumber) {\r\n        returnValue = source.BusinessPhoneNumber.number;\r\n    };\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "BusinessPhoneNumber_number",
             "validation": {
                 "required": false
             }
         },
         {
             "name": "Contact.Business.Phone.Mobile",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof source.MobilePhoneNumber !== 'undefined' && source.MobilePhoneNumber) {\r\n        returnValue = source.MobilePhoneNumber.number;\r\n    };\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "MobilePhoneNumber_number",
             "validation": {
                 "required": false
             }
         },
         {
             "name": "Contact.Personal.Email",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof source.PrivateEmailAddress !== 'undefined' && source.PrivateEmailAddress) {\r\n        returnValue = source.PrivateEmailAddress.address;\r\n    };\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "PrivateEmailAddress_address",
             "validation": {
                 "required": false
             }
         },
         {
             "name": "Details.Gender",
-            "mode": "field",
-            "value": "gender",
+            "mode": "complex",
+            "value": "function getValue() {\r\n    let returnValue = '';\r\n\r\n    switch (source.gender) {\r\n        case \"Female\": {\r\n            returnValue = \"V\";\r\n            break;\r\n        }\r\n        case \"Male\": {\r\n            returnValue = \"M\";\r\n            break;\r\n        }\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -51,7 +51,7 @@
         {
             "name": "Name.Convention",
             "mode": "complex",
-            "value": "function getValue() {\r\n    let returnValue = '';\r\n\r\n    switch (source.nameAssembleOrder) {\r\n        case \"P\": {\r\n            returnValue = \"P\";\r\n            break;\r\n        }\r\n        case \"E\": {\r\n            returnValue = \"B\";\r\n            break;\r\n        }\r\n        case \"B\": {\r\n            returnValue = \"PB\";\r\n            break;\r\n        }\r\n        case \"C\": {\r\n            returnValue = \"BP\";\r\n            break;\r\n        }\r\n        case \"D\": {\r\n            returnValue = \"BP\";\r\n            break;\r\n        }\r\n        default: {\r\n            returnValue = \"B\";\r\n            break;\r\n        }\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n \r\ngetValue();",
+            "value": "function getValue() {\r\n    let returnValue = '';\r\n\r\n    switch (source.nameAssembleOrder) {\r\n        case \"P\": {\r\n            returnValue = \"P\";\r\n            break;\r\n        }\r\n        case \"E\": {\r\n            returnValue = \"B\";\r\n            break;\r\n        }\r\n        case \"B\": {\r\n            returnValue = \"PB\";\r\n            break;\r\n        }\r\n        case \"C\": {\r\n            returnValue = \"BP\";\r\n            break;\r\n        }\r\n        case \"D\": {\r\n            returnValue = \"BP\";\r\n            break;\r\n        }\r\n        default: {\r\n            returnValue = \"B\";\r\n            break;\r\n        }\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -116,24 +116,24 @@
     "contractMappings": [
         {
             "name": "CostCenter.Code",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof sourceContract.assignment_costAllocation !== 'undefined' && sourceContract.assignment_costAllocation) {\r\n        returnValue = sourceContract.assignment_costAllocation.costCenterCode;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "assignment_costAllocation_costCenterCode",
             "validation": {
                 "required": false
             }
         },
         {
             "name": "CostCenter.ExternalId",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof sourceContract.assignment_costAllocation !== 'undefined' && sourceContract.assignment_costAllocation) {\r\n        returnValue = sourceContract.assignment_costAllocation.costCenterCode;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "assignment_costAllocation_costCenterCode",
             "validation": {
                 "required": false
             }
         },
         {
             "name": "CostCenter.Name",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof sourceContract.assignment_costAllocation !== 'undefined' && sourceContract.assignment_costAllocation) {\r\n        returnValue = sourceContract.assignment_costAllocation.costCenterName;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "assignment_costAllocation_costCenterName",
             "validation": {
                 "required": false
             }
@@ -141,7 +141,7 @@
         {
             "name": "Department.DisplayName",
             "mode": "field",
-            "value": "assignment_organizationUnitName",
+            "value": "assignment_organizationUnit_fullName",
             "validation": {
                 "required": false
             }
@@ -149,7 +149,7 @@
         {
             "name": "Department.ExternalId",
             "mode": "field",
-            "value": "assignment_organizationUnit",
+            "value": "assignment_organizationUnit_id",
             "validation": {
                 "required": false
             }
@@ -163,9 +163,25 @@
             }
         },
         {
-            "name": "EndDate",
+            "name": "Employer.Code",
             "mode": "field",
-            "value": "function getValue(){\r\n    returnValue = sourceContract.assignment_endDate;\r\n\r\n    if(sourceContract.assignment_endDate == '9999-12-31'){\r\n        returnValue = null;\r\n    }\r\n    return returnValue;\r\n}\r\n\r\ngetValue()",
+            "value": "employment_payrollClientCode",
+            "validation": {
+                "required": false
+            }
+        },
+        {
+            "name": "Employer.ExternalId",
+            "mode": "field",
+            "value": "employment_payrollClientCode",
+            "validation": {
+                "required": false
+            }
+        },
+        {
+            "name": "EndDate",
+            "mode": "complex",
+            "value": "function getValue(){\r\n    returnValue = sourceContract.assignment_endDate;\r\n\r\n    if(sourceContract.assignment_endDate == '9999-12-31'){\r\n        returnValue = null;\r\n    }\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -203,9 +219,17 @@
             }
         },
         {
+            "name": "Title.Code",
+            "mode": "field",
+            "value": "assignment_jobProfile_shortName",
+            "validation": {
+                "required": false
+            }
+        },
+        {
             "name": "Title.ExternalId",
             "mode": "field",
-            "value": "assignment_jobProfile.shortName",
+            "value": "assignment_jobProfile_id",
             "validation": {
                 "required": false
             }
@@ -213,7 +237,7 @@
         {
             "name": "Title.Name",
             "mode": "field",
-            "value": "assignment_jobProfile.fullName",
+            "value": "assignment_jobProfile_fullName",
             "validation": {
                 "required": false
             }

--- a/mapping.employments.json
+++ b/mapping.employments.json
@@ -2,40 +2,40 @@
     "personMappings": [
         {
             "name": "Contact.Business.Email",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof source.BusinessEmailAddress !== 'undefined' && source.BusinessEmailAddress) {\r\n        returnValue = source.BusinessEmailAddress.address;\r\n    };\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "BusinessEmailAddress_address",
             "validation": {
                 "required": false
             }
         },
         {
             "name": "Contact.Business.Phone.Fixed",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof source.BusinessPhoneNumber !== 'undefined' && source.BusinessPhoneNumber) {\r\n        returnValue = source.BusinessPhoneNumber.number;\r\n    };\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "BusinessPhoneNumber_number",
             "validation": {
                 "required": false
             }
         },
         {
             "name": "Contact.Business.Phone.Mobile",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof source.MobilePhoneNumber !== 'undefined' && source.MobilePhoneNumber) {\r\n        returnValue = source.MobilePhoneNumber.number;\r\n    };\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "MobilePhoneNumber_number",
             "validation": {
                 "required": false
             }
         },
         {
             "name": "Contact.Personal.Email",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof source.PrivateEmailAddress !== 'undefined' && source.PrivateEmailAddress) {\r\n        returnValue = source.PrivateEmailAddress.address;\r\n    };\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "PrivateEmailAddress_address",
             "validation": {
                 "required": false
             }
         },
         {
             "name": "Details.Gender",
-            "mode": "field",
-            "value": "gender",
+            "mode": "complex",
+            "value": "function getValue() {\r\n    let returnValue = '';\r\n\r\n    switch (source.gender) {\r\n        case \"Female\": {\r\n            returnValue = \"V\";\r\n            break;\r\n        }\r\n        case \"Male\": {\r\n            returnValue = \"M\";\r\n            break;\r\n        }\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -51,7 +51,7 @@
         {
             "name": "Name.Convention",
             "mode": "complex",
-            "value": "function getValue() {\r\n    let returnValue = '';\r\n\r\n    switch (source.nameAssembleOrder) {\r\n        case \"P\": {\r\n            returnValue = \"P\";\r\n            break;\r\n        }\r\n        case \"E\": {\r\n            returnValue = \"B\";\r\n            break;\r\n        }\r\n        case \"B\": {\r\n            returnValue = \"PB\";\r\n            break;\r\n        }\r\n        case \"C\": {\r\n            returnValue = \"BP\";\r\n            break;\r\n        }\r\n        case \"D\": {\r\n            returnValue = \"BP\";\r\n            break;\r\n        }\r\n        default: {\r\n            returnValue = \"B\";\r\n            break;\r\n        }\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n \r\ngetValue();",
+            "value": "function getValue() {\r\n    let returnValue = '';\r\n\r\n    switch (source.nameAssembleOrder) {\r\n        case \"P\": {\r\n            returnValue = \"P\";\r\n            break;\r\n        }\r\n        case \"E\": {\r\n            returnValue = \"B\";\r\n            break;\r\n        }\r\n        case \"B\": {\r\n            returnValue = \"PB\";\r\n            break;\r\n        }\r\n        case \"C\": {\r\n            returnValue = \"BP\";\r\n            break;\r\n        }\r\n        case \"D\": {\r\n            returnValue = \"BP\";\r\n            break;\r\n        }\r\n        default: {\r\n            returnValue = \"B\";\r\n            break;\r\n        }\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -116,24 +116,24 @@
     "contractMappings": [
         {
             "name": "CostCenter.Code",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof sourceContract.employment_costAllocation !== 'undefined' && sourceContract.employment_costAllocation) {\r\n        returnValue = sourceContract.employment_costAllocation.costCenterCode;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "employment_costAllocation_costCenterCode",
             "validation": {
                 "required": false
             }
         },
         {
             "name": "CostCenter.ExternalId",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof sourceContract.employment_costAllocation !== 'undefined' && sourceContract.employment_costAllocation) {\r\n        returnValue = sourceContract.employment_costAllocation.costCenterCode;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "employment_costAllocation_costCenterCode",
             "validation": {
                 "required": false
             }
         },
         {
             "name": "CostCenter.Name",
-            "mode": "complex",
-            "value": "function getValue(){\r\n    returnValue = null;\r\n\r\n    if (typeof sourceContract.employment_costAllocation !== 'undefined' && sourceContract.employment_costAllocation) {\r\n        returnValue = sourceContract.employment_costAllocation.costCenterName;\r\n    }\r\n\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
+            "mode": "field",
+            "value": "employment_costAllocation_costCenterName",
             "validation": {
                 "required": false
             }
@@ -141,7 +141,7 @@
         {
             "name": "Department.DisplayName",
             "mode": "field",
-            "value": "employment_organizationUnitName",
+            "value": "employment_organizationUnit_fullName",
             "validation": {
                 "required": false
             }
@@ -149,7 +149,15 @@
         {
             "name": "Department.ExternalId",
             "mode": "field",
-            "value": "employment_organizationUnit",
+            "value": "employment_organizationUnit_id",
+            "validation": {
+                "required": false
+            }
+        },
+        {
+            "name": "Details.Fte",
+            "mode": "field",
+            "value": "employment_workingAmount.parttimePercentage",
             "validation": {
                 "required": false
             }
@@ -163,9 +171,41 @@
             }
         },
         {
-            "name": "EndDate",
+            "name": "Details.Percentage",
             "mode": "field",
-            "value": "function getValue(){\r\n    returnValue = sourceContract.employment_dischargeDate;\r\n\r\n    if(sourceContract.employment_dischargeDate == '9999-12-31'){\r\n        returnValue = null;\r\n    }\r\n    return returnValue;\r\n}\r\n\r\ngetValue()",
+            "value": "employment_workingAmount.parttimePercentage",
+            "validation": {
+                "required": false
+            }
+        },
+        {
+            "name": "Details.Sequence",
+            "mode": "field",
+            "value": "employment_contractCode",
+            "validation": {
+                "required": false
+            }
+        },
+        {
+            "name": "Employer.Code",
+            "mode": "field",
+            "value": "employment_payrollClientCode",
+            "validation": {
+                "required": false
+            }
+        },
+        {
+            "name": "Employer.ExternalId",
+            "mode": "field",
+            "value": "employment_payrollClientCode",
+            "validation": {
+                "required": false
+            }
+        },
+        {
+            "name": "EndDate",
+            "mode": "complex",
+            "value": "function getValue(){\r\n    returnValue = sourceContract.employment_dischargeDate;\r\n\r\n    if(sourceContract.employment_dischargeDate == '9999-12-31'){\r\n        returnValue = null;\r\n    }\r\n    return returnValue;\r\n}\r\n\r\ngetValue();",
             "validation": {
                 "required": false
             }
@@ -176,6 +216,14 @@
             "value": "employment_id",
             "validation": {
                 "required": true
+            }
+        },
+        {
+            "name": "Organization.Code",
+            "mode": "field",
+            "value": "employment_company",
+            "validation": {
+                "required": false
             }
         },
         {
@@ -203,9 +251,17 @@
             }
         },
         {
+            "name": "Title.Code",
+            "mode": "field",
+            "value": "employment_jobProfile_shortName",
+            "validation": {
+                "required": false
+            }
+        },
+        {
             "name": "Title.ExternalId",
             "mode": "field",
-            "value": "employment_jobProfile.shortName",
+            "value": "employment_jobProfile_id",
             "validation": {
                 "required": false
             }
@@ -213,7 +269,7 @@
         {
             "name": "Title.Name",
             "mode": "field",
-            "value": "employment_jobProfile.fullName",
+            "value": "employment_jobProfile_fullName",
             "validation": {
                 "required": false
             }


### PR DESCRIPTION
Updated the handling of all extra data to keep the person object flat, instead of an object with "subobjects" in it, for e.g. costallocation, organizationunit, etc.
For a number of reasons, performance and simply ease of implementation, this is not useful. So this is the reason for the change.